### PR TITLE
Accept java.time.Instant as a valid type for keys

### DIFF
--- a/src/codax/pathwise.clj
+++ b/src/codax/pathwise.clj
@@ -76,6 +76,15 @@
 (defn decode-date-time [d]
   (time-format/parse date-time-formatter (string/join d)))
 
+(defn java-time? [x]
+  (instance? java.time.Instant x))
+
+(defn encode-java-time [t]
+  (str t))
+
+(defn decode-java-time [t]
+  (java.time.Instant/parse (string/join t)))
+
 (defmacro build-encoding-functions [type-specs]
   (let [el (gensym "el")
         type-char (gensym "type-char")
@@ -126,6 +135,10 @@
               :hex 0x24
               :encoder encode-date-time
               :decoder decode-date-time}
+  :java-time {:predicate java-time?
+              :hex 0x25
+              :encoder encode-java-time
+              :decoder decode-java-time}
   :neg-infinity {:predicate neg-infinity?
                  :hex 0x30
                  :encoder (fn [_] "")


### PR DESCRIPTION
Because it is possible to convert losslessly between Instant, ZonedDateTime and
OffsetDateTime, we could choose to put the latter two in the same hex tag, so
they may be ordered relative to each other. We would need to come up a string
representation that includes the offset or the zone, and the right
encoder/decoder fns.

In that case, it should be possible to extend the string representation further
so joda time objects can also be compared, and so on for all DateTime objects
which map directly to epoch time.

The current implementation only allows java.time.Instant.

#4 