### PR TITLE
Thread safe connections

### DIFF
--- a/src/codax/core.clj
+++ b/src/codax/core.clj
@@ -8,7 +8,7 @@
 
 (defn open-database
   "Opens a database at the given filepath. If a database is already open at the given path
-  an Exception is thrown.
+  the existing database connection is returned.
 
   By default a set of files in the database directory with the suffix ARCHIVE are created or
   overwritten on each compaction and represent the most recent pre-compaction state.

--- a/test/codax/store_test.clj
+++ b/test/codax/store_test.clj
@@ -18,10 +18,13 @@
 (use-fixtures :each store-setup-and-teardown)
 
 (deftest attempt-reopen
+  (is (= *testing-database* (open-database (:path *testing-database*)))))
+
+(deftest attempt-reopen-with-different-backup-fn
   (is (thrown-with-msg?
        Exception
-       #"Database Already Open"
-       (open-database (:path *testing-database*)))))
+       #"Mismatched Backup Functions"
+       (open-database (:path *testing-database*) (fn [] )))))
 
 (deftest open-non-folder
   (spit "test-databases/non-folder" "content")


### PR DESCRIPTION
`open-database` `close-database` and `destroy-database` are fully thread safe. This comes at the expense of a global lock which could be a bottleneck in situations where many databases are being opened and closed.

`open-database` is also idempotent. Instead of throwing an error, attempting to open an already open database will return the existing database connection.