### PR TITLE
Fix clj-time.format/formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Write transactions block other write transactions (though they do not block read
 ## Examples
 
 ``` clojure
-(require [codax.core :as c])
+(require '[codax.core :as c])
 ```
 
 ### Simple Use

--- a/src/codax/pathwise.clj
+++ b/src/codax/pathwise.clj
@@ -65,7 +65,7 @@
 (defn encode-string [s] s)
 (defn decode-string [s] (string/join s))
 
-(def joda-time-formatter (joda-time-format/formatter :basic-date-time))
+(def joda-time-formatter (joda-time-format/formatters :basic-date-time))
 
 (defn joda-time? [x]
   (instance? org.joda.time.DateTime x))


### PR DESCRIPTION
Library currently crashes during load due to this issue.