### PR TITLE
Created a function 'next-id!' which generates next available autoincremented ID for the specified entity

### DIFF
--- a/src/codax/operations.clj
+++ b/src/codax/operations.clj
@@ -228,3 +228,31 @@
   (when (empty? path) (throw (ex-info "Invalid Path" {:cause :empty-path
                                                       :message "You cannot clear the empty (root) path."})))
   (clear-path tx path))
+
+
+;;;;;
+
+(defn next-id!
+  "Function generates auto incremented id starting from 0 for the specified entity.
+  Parameters:
+    db -- opened database
+    entity -- the entity for which the id should be generated.
+  Return:
+    The value of the next available id for the specified entity.
+  Usage examples:
+    (next-id! db :person) => 0
+    (-> db (next-id! :person)) => 1
+  "
+  [ db entity ]
+  (let [n (atom nil)]    
+    (c/with-write-transaction [db tx]
+      
+      ;; Read previous index value. If it is absent -- use 0 instead;
+      (reset! n (or (c/get-at! db [:codax/indicies entity]) 0))
+      
+      ;; Create or update the next index value with incremented previous value
+      (c/assoc-at tx [:codax/indicies entity] (inc @n)))
+
+    ;; Return original index value
+    @n))
+

--- a/src/codax/store.clj
+++ b/src/codax/store.clj
@@ -284,6 +284,11 @@
       (swap! open-databases assoc path db)
       db)))
 
+(defn connection [ path ]
+  (let [full-path (to-canonical-path-string path)
+        con (get @open-databases full-path)]
+      (or con (open-database path))))
+
 ;;;;; Transactions
 
 (defn- update-database! [{:keys [db root-id id-counter manifest]} nodes-offset manifest-delta nodes-by-address]


### PR DESCRIPTION
Usually we need to insert the entity using a unique ID for it. Function 'next-id!' generates such ID.