### PR TITLE
Protect against RCE vulnerability in Nippy

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/dscarpetti/codax"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.taoensso/nippy "2.14.0"]
+  :dependencies [[com.taoensso/nippy "3.2.0"]
                  [clj-time "0.13.0"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/core.cache "0.6.5"]]


### PR DESCRIPTION
"Nippy versions from v2.5.0-beta1 (24 Oct 2013) and before v2.15.0 final (24 Jul 2020) contain an RCE (Remote Code Execution) vulnerability that may allow an attacker to execute arbitrary code when thawing a malicious payload controlled by the attacker."

https://github.com/taoensso/nippy/issues/130