### PR TITLE
remove clj-time dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,6 @@
 
 * remove deprecated clj-time dependency
 
-## 1.4.0 (2023-07-20)
-
-* implement upgradable transactions (using `with-upgradable-transaction` macro)
-* update taoensso/nippy to 3.2.0 to address RCE vulnerability: [taoensso/nippy#130](https://github.com/taoensso/nippy/issues/130)
-
-### Upgrading From 1.3.1
-
-The upgraded nippy requires non-standard types to be whitelisted before they can be decoded. When opening a database created with an earlier version of codax nippy may throw security errors when thawing non-standard values. This is easily corrected. See discussion in [#30](https://github.com/dscarpetti/codax/pull/30)
-
 If an existing database made use of joda/clj-time times you will need to renable support by including the clj-time dependency in your project and defining the path type with:
 
 ``` clojure
@@ -24,6 +15,15 @@ If an existing database made use of joda/clj-time times you will need to renable
   (partial joda/parse (joda/formatters :basic-date-time)))
 
 ```
+
+## 1.4.0 (2023-07-20)
+
+* implement upgradable transactions (using `with-upgradable-transaction` macro)
+* update taoensso/nippy to 3.2.0 to address RCE vulnerability: [taoensso/nippy#130](https://github.com/taoensso/nippy/issues/130)
+
+### Upgrading From 1.3.1
+
+The upgraded nippy requires non-standard types to be whitelisted before they can be decoded. When opening a database created with an earlier version of codax nippy may throw security errors when thawing non-standard values. This is easily corrected. See discussion in [#30](https://github.com/dscarpetti/codax/pull/30)
 
 ## 1.3.1 (2019-05-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,23 @@
 
 * implement upgradable transactions (using `with-upgradable-transaction` macro)
 * update taoensso/nippy to 3.2.0 to address RCE vulnerability: [taoensso/nippy#130](https://github.com/taoensso/nippy/issues/130)
+* remove deprecated clj-time dependency
 
 ### Upgrading From 1.3.1
 
 The upgraded nippy requires non-standard types to be whitelisted before they can be decoded. When opening a database created with an earlier version of codax nippy may throw security errors when thawing non-standard values. This is easily corrected. See discussion in [#30](https://github.com/dscarpetti/codax/pull/30)
+
+If an existing database made use of joda/clj-time times you will need to renable support by including the clj-time dependency in your project and defining the path type with:
+
+``` clojure
+
+(require [clj-time.format :as joda])
+
+(defpathtype [0x24 org.joda.time.DateTime]
+  (partial joda/unparse (joda/formatters :basic-date-time))
+  (partial joda/parse (joda/formatters :basic-date-time)))
+
+```
 
 ## 1.3.1 (2019-05-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Change Log
 
+## 1.4.1 (2025-06-20)
+
+* remove deprecated clj-time dependency
+
 ## 1.4.0 (2023-07-20)
 
 * implement upgradable transactions (using `with-upgradable-transaction` macro)
 * update taoensso/nippy to 3.2.0 to address RCE vulnerability: [taoensso/nippy#130](https://github.com/taoensso/nippy/issues/130)
-* remove deprecated clj-time dependency
 
 ### Upgrading From 1.3.1
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Codax is an idiomatic transactional embedded database for clojure. A codax datab
 
 [![Clojars Project](http://clojars.org/codax/latest-version.svg)](http://clojars.org/codax)
 
-Version 1.4.0+ implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro), removes built-in support for clj-time, and **fixes an RCE vulnerability**.
+Version 1.4.1 removes built-in support for clj-time. If you have an older database using clj-time see the [changelog](CHANGELOG.md)
 
-See the [changelog](CHANGELOG.md) for details on upgrading from earlier codax versions.
+Version 1.4.0 implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro) and **fixes an RCE vulnerability**.
 
 ### The Why
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Codax is an idiomatic transactional embedded database for clojure. A codax datab
 
 [![Clojars Project](http://clojars.org/codax/latest-version.svg)](http://clojars.org/codax)
 
-Version 1.4.0 implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro) and **fixes an RCE vulnerability**.
+Version 1.4.0 implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro), removes built-in support for clj-time, and **fixes an RCE vulnerability**.
 
 See the [changelog](CHANGELOG.md) for details on upgrading from earlier codax versions.
 
@@ -101,7 +101,6 @@ A `path` is a vector of keys similar to the `[k & ks]` used in function like `as
     - false
     - nil
     - java.time.Instant
-    - org.joda.time.DateTime
   - the path can only target nested maps, and **cannot be used to descend into other data structures (e.g. vectors)**.
   - you can get the empty path (e.g. `(get-at db [])` returns the full database) but you cannot modify it (e.g. `(assoc-at [] :foo)` throws an error)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Codax is an idiomatic transactional embedded database for clojure. A codax datab
 
 [![Clojars Project](http://clojars.org/codax/latest-version.svg)](http://clojars.org/codax)
 
-Version 1.4.0 implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro), removes built-in support for clj-time, and **fixes an RCE vulnerability**.
+Version 1.4.0+ implements [upgradable transactions](doc/upgradable-transactions.md). (using `with-upgradable-transaction` macro), removes built-in support for clj-time, and **fixes an RCE vulnerability**.
 
 See the [changelog](CHANGELOG.md) for details on upgrading from earlier codax versions.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject codax "1.4.0-SNAPSHOT"
+(defproject codax "1.4.1"
   :description "Codax is an idiomatic transactional embedded database for clojure"
   :url "https://github.com/dscarpetti/codax"
   :license {:name "Eclipse Public License"

--- a/src/codax/pathwise.clj
+++ b/src/codax/pathwise.clj
@@ -1,7 +1,6 @@
 (ns codax.pathwise
   (:require
-   [clojure.string :as str]
-   [clj-time.format :as joda]))
+   [clojure.string :as str]))
 
 (def +delim+ (char 0x00))
 (def +vector+ (char 0xa0))
@@ -110,10 +109,6 @@
 (defpathtype [0x70 java.lang.String] identity identity)
 
 (defpathtype [0x25 java.time.Instant] str java.time.Instant/parse)
-
-(defpathtype [0x24 org.joda.time.DateTime]
-  (partial joda/unparse (joda/formatters :basic-date-time))
-  (partial joda/parse (joda/formatters :basic-date-time)))
 
 (defpathtype [0xa0 clojure.lang.PersistentVector clojure.lang.PersistentList]
   #(apply str (map encode %))

--- a/test/codax/pathwise_test.clj
+++ b/test/codax/pathwise_test.clj
@@ -3,7 +3,6 @@
    [codax.test-logging :refer [logln]]
    [codax.pathwise :refer :all]
    [codax.pathwise-legacy :as legacy]
-   [clj-time.core :as joda]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.pprint :refer [pprint]]))
@@ -74,11 +73,9 @@
 
 (defet long-string-val "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty")
 
-(defet joda-time (joda/now))
-
 (defet java-time (java.time.Instant/now))
 
-(defet vec-1 [0 0.0 -1 1 -1.1 1.1 nil true false 'symbol "string" :keyword (joda/now) (java.time.Instant/now)])
+(defet vec-1 [0 0.0 -1 1 -1.1 1.1 nil true false 'symbol "string" :keyword (java.time.Instant/now)])
 (defet vec-2 [nil])
 (defet vec-3 [nil nil])
 (defet vec-4 [nil nil nil])


### PR DESCRIPTION
remove deprecated clj-time library and include instructions for re-enabling for those who have legacy databases that depend on it.